### PR TITLE
Mark raw_c2_config as required

### DIFF
--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -592,7 +592,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		Description:   "Agent configuration in JSON or TOML file",
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_FILE,
-		Required:      false,
+		Required:      true,
 	},
 	{
 		Name:          "callback_domains",


### PR DESCRIPTION
`raw_c2_config` is marked `Required: false` but ConfigCheckFunction, GetRedirectorRules, GetIOC, and SampleMessage all unconditionally call `GetFileArg("raw_c2_config")` and fail if it's missing. The server also can't register any routes without it since `agent_configs.json` starts empty.

This just makes the parameter definition match the actual behavior. Also enables correct usage by LLMs via MCP tooling.