### PR TITLE
Feature parity with http and updates

### DIFF
--- a/C2_Profiles/httpx/Dockerfile
+++ b/C2_Profiles/httpx/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /Mythic/
 

--- a/C2_Profiles/httpx/Dockerfile
+++ b/C2_Profiles/httpx/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /Mythic/
 
 COPY [".", "."]
 
+RUN go mod tidy && cd httpx/c2_code && go mod tidy && cd /Mythic/
+
 RUN make build
 
 FROM alpine

--- a/C2_Profiles/httpx/go.mod
+++ b/C2_Profiles/httpx/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.3
 
 require (
 	github.com/Khan/genqlient v0.8.0
-	github.com/MythicMeta/MythicContainer v1.4.19
+	github.com/MythicMeta/MythicContainer v1.6.4
 	github.com/pelletier/go-toml v1.9.5
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
 )

--- a/C2_Profiles/httpx/go.mod
+++ b/C2_Profiles/httpx/go.mod
@@ -1,8 +1,6 @@
 module MyContainer
 
-go 1.23.0
-
-toolchain go1.23.3
+go 1.25.1
 
 //replace github.com/MythicMeta/MythicContainer => ../../../../MythicMeta/MythicContainer
 

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -588,20 +588,12 @@ RewriteCond %%{HTTP_USER_AGENT} "%s"`
 }
 var httpxc2parameters = []c2structs.C2Parameter{
 	{
-		Name:          "raw_c2_config",
-		Description:   "Agent configuration in JSON or TOML file",
-		DefaultValue:  "",
-		ParameterType: c2structs.C2_PARAMETER_TYPE_FILE,
-		Required:      true,
-		UiPosition:    1,
-	},
-	{
 		Name:          "callback_domains",
 		Description:   "Array of callback domains as http(s)://host:port (e.g. https://example.com:443)",
 		DefaultValue:  []string{"https://example.com:443"},
 		ParameterType: c2structs.C2_PARAMETER_TYPE_ARRAY,
 		Required:      true,
-		UiPosition:    2,
+		UiPosition:    1,
 	},
 	{
 		Name:          "domain_rotation",
@@ -612,14 +604,14 @@ var httpxc2parameters = []c2structs.C2Parameter{
 			"round-robin",
 			"random",
 		},
-		UiPosition: 3,
+		UiPosition: 2,
 	},
 	{
 		Name:          "failover_threshold",
 		Description:   "Domain fail-over threshold for how many times to keep trying one host before moving onto the next",
 		DefaultValue:  5,
 		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
-		UiPosition:    4,
+		UiPosition:    3,
 	},
 	{
 		Name:          "AESPSK",
@@ -632,7 +624,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 			"aes256_hmac",
 			"none",
 		},
-		UiPosition: 5,
+		UiPosition: 4,
 	},
 	{
 		Name:          "encrypted_exchange_check",
@@ -640,7 +632,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  true,
 		ParameterType: c2structs.C2_PARAMETER_TYPE_BOOLEAN,
 		Required:      false,
-		UiPosition:    6,
+		UiPosition:    5,
 	},
 	{
 		Name:          "callback_interval",
@@ -649,7 +641,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
 		Required:      false,
 		VerifierRegex: "^[0-9]+$",
-		UiPosition:    7,
+		UiPosition:    6,
 	},
 	{
 		Name:          "callback_jitter",
@@ -658,7 +650,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
 		Required:      false,
 		VerifierRegex: "^[0-9]+$",
-		UiPosition:    8,
+		UiPosition:    7,
 	},
 	{
 		Name:          "killdate",
@@ -666,7 +658,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  365,
 		ParameterType: c2structs.C2_PARAMETER_TYPE_DATE,
 		Required:      false,
-		UiPosition:    9,
+		UiPosition:    8,
 	},
 	{
 		Name:          "proxy_host",
@@ -674,7 +666,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
-		UiPosition:    10,
+		UiPosition:    9,
 	},
 	{
 		Name:          "proxy_user",
@@ -682,7 +674,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
-		UiPosition:    11,
+		UiPosition:    10,
 	},
 	{
 		Name:          "proxy_pass",
@@ -690,6 +682,14 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
+		UiPosition:    11,
+	},
+	{
+		Name:          "raw_c2_config",
+		Description:   "Agent configuration in JSON or TOML file",
+		DefaultValue:  "",
+		ParameterType: c2structs.C2_PARAMETER_TYPE_FILE,
+		Required:      true,
 		UiPosition:    12,
 	},
 }

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -659,6 +659,35 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		ParameterType: c2structs.C2_PARAMETER_TYPE_DATE,
 		Required:      false,
 	},
+	{
+		Name:          "proxy_host",
+		Description:   "Proxy host in format host:port",
+		DefaultValue:  "",
+		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+		Required:      false,
+	},
+	{
+		Name:          "proxy_port",
+		Description:   "Proxy port",
+		DefaultValue:  "",
+		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+		Required:      false,
+		VerifierRegex: "^[0-9]*$",
+	},
+	{
+		Name:          "proxy_user",
+		Description:   "Proxy username",
+		DefaultValue:  "",
+		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+		Required:      false,
+	},
+	{
+		Name:          "proxy_pass",
+		Description:   "Proxy password",
+		DefaultValue:  "",
+		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
+		Required:      false,
+	},
 }
 
 func validateAndUpdateConfig(agentConfigFileID string) error {

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -120,9 +120,8 @@ var httpxc2definition = c2structs.C2Profile{
 		// this is where we will need to update the config with what the agent supplied
 		// this is called each time a new payload is created, so update the server's config with the agent's config
 		agentConfigFileID, err := message.GetFileArg("raw_c2_config")
-		if err != nil {
-			response.Success = false
-			response.Error += fmt.Sprintf("Error getting agent_config: %v\n", err)
+		if err != nil || agentConfigFileID == "" {
+			response.Message = "No agent config file supplied, skipping config check."
 			return response
 		}
 		err = validateAndUpdateConfig(agentConfigFileID)
@@ -141,9 +140,8 @@ var httpxc2definition = c2structs.C2Profile{
 			Message: fmt.Sprintf("Called redirector status check:\n%v", message),
 		}
 		agentConfigFileID, err := message.GetFileArg("raw_c2_config")
-		if err != nil {
-			response.Success = false
-			response.Error += fmt.Sprintf("Error getting agent_config: %v\n", err)
+		if err != nil || agentConfigFileID == "" {
+			response.Message = "No agent config file supplied, skipping redirector rules."
 			return response
 		}
 		agentConfigContents, err := mythicrpc.SendMythicRPCFileGetContent(mythicrpc.MythicRPCFileGetContentMessage{
@@ -258,9 +256,8 @@ RewriteCond %%{HTTP_USER_AGENT} "%s"`
 	GetIOCFunction: func(message c2structs.C2GetIOCMessage) c2structs.C2GetIOCMessageResponse {
 		response := c2structs.C2GetIOCMessageResponse{Success: true}
 		agentConfigFileID, err := message.GetFileArg("raw_c2_config")
-		if err != nil {
-			response.Success = false
-			response.Error += fmt.Sprintf("Error getting agent_config: %v\n", err)
+		if err != nil || agentConfigFileID == "" {
+			response.Message = "No agent config file supplied, skipping IOC generation."
 			return response
 		}
 		agentConfigContents, err := mythicrpc.SendMythicRPCFileGetContent(mythicrpc.MythicRPCFileGetContentMessage{
@@ -333,9 +330,8 @@ RewriteCond %%{HTTP_USER_AGENT} "%s"`
 	SampleMessageFunction: func(message c2structs.C2SampleMessageMessage) c2structs.C2SampleMessageResponse {
 		response := c2structs.C2SampleMessageResponse{Success: true, Message: "\n"}
 		agentConfigFileID, err := message.GetFileArg("raw_c2_config")
-		if err != nil {
-			response.Success = false
-			response.Error += fmt.Sprintf("Error getting agent_config: %v\n", err)
+		if err != nil || agentConfigFileID == "" {
+			response.Message = "No agent config file supplied, skipping sample message."
 			return response
 		}
 		agentConfigContents, err := mythicrpc.SendMythicRPCFileGetContent(mythicrpc.MythicRPCFileGetContentMessage{
@@ -689,7 +685,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		Description:   "Agent configuration in JSON or TOML file",
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_FILE,
-		Required:      true,
+		Required:      false,
 		UiPosition:    12,
 	},
 }

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -667,14 +667,6 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		Required:      false,
 	},
 	{
-		Name:          "proxy_port",
-		Description:   "Proxy port",
-		DefaultValue:  "",
-		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
-		Required:      false,
-		VerifierRegex: "^[0-9]*$",
-	},
-	{
 		Name:          "proxy_user",
 		Description:   "Proxy username",
 		DefaultValue:  "",

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -593,6 +593,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_FILE,
 		Required:      true,
+		UiPosition:    1,
 	},
 	{
 		Name:          "callback_domains",
@@ -600,6 +601,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  []string{"https://example.com:443"},
 		ParameterType: c2structs.C2_PARAMETER_TYPE_ARRAY,
 		Required:      true,
+		UiPosition:    2,
 	},
 	{
 		Name:          "domain_rotation",
@@ -610,27 +612,14 @@ var httpxc2parameters = []c2structs.C2Parameter{
 			"round-robin",
 			"random",
 		},
+		UiPosition: 3,
 	},
 	{
 		Name:          "failover_threshold",
 		Description:   "Domain fail-over threshold for how many times to keep trying one host before moving onto the next",
 		DefaultValue:  5,
 		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
-	},
-	{
-		Name:          "encrypted_exchange_check",
-		Description:   "Perform Key Exchange",
-		DefaultValue:  true,
-		ParameterType: c2structs.C2_PARAMETER_TYPE_BOOLEAN,
-		Required:      false,
-	},
-	{
-		Name:          "callback_jitter",
-		Description:   "Callback Jitter in percent",
-		DefaultValue:  23,
-		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
-		Required:      false,
-		VerifierRegex: "^[0-9]+$",
+		UiPosition:    4,
 	},
 	{
 		Name:          "AESPSK",
@@ -643,6 +632,15 @@ var httpxc2parameters = []c2structs.C2Parameter{
 			"aes256_hmac",
 			"none",
 		},
+		UiPosition: 5,
+	},
+	{
+		Name:          "encrypted_exchange_check",
+		Description:   "Perform Key Exchange",
+		DefaultValue:  true,
+		ParameterType: c2structs.C2_PARAMETER_TYPE_BOOLEAN,
+		Required:      false,
+		UiPosition:    6,
 	},
 	{
 		Name:          "callback_interval",
@@ -651,6 +649,16 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
 		Required:      false,
 		VerifierRegex: "^[0-9]+$",
+		UiPosition:    7,
+	},
+	{
+		Name:          "callback_jitter",
+		Description:   "Callback Jitter in percent",
+		DefaultValue:  23,
+		ParameterType: c2structs.C2_PARAMETER_TYPE_NUMBER,
+		Required:      false,
+		VerifierRegex: "^[0-9]+$",
+		UiPosition:    8,
 	},
 	{
 		Name:          "killdate",
@@ -658,6 +666,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  365,
 		ParameterType: c2structs.C2_PARAMETER_TYPE_DATE,
 		Required:      false,
+		UiPosition:    9,
 	},
 	{
 		Name:          "proxy_host",
@@ -665,6 +674,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
+		UiPosition:    10,
 	},
 	{
 		Name:          "proxy_user",
@@ -672,6 +682,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
+		UiPosition:    11,
 	},
 	{
 		Name:          "proxy_pass",
@@ -679,6 +690,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 		DefaultValue:  "",
 		ParameterType: c2structs.C2_PARAMETER_TYPE_STRING,
 		Required:      false,
+		UiPosition:    12,
 	},
 }
 

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -257,7 +257,6 @@ RewriteCond %%{HTTP_USER_AGENT} "%s"`
 		response := c2structs.C2GetIOCMessageResponse{Success: true}
 		agentConfigFileID, err := message.GetFileArg("raw_c2_config")
 		if err != nil || agentConfigFileID == "" {
-			response.Message = "No agent config file supplied, skipping IOC generation."
 			return response
 		}
 		agentConfigContents, err := mythicrpc.SendMythicRPCFileGetContent(mythicrpc.MythicRPCFileGetContentMessage{

--- a/C2_Profiles/httpx/httpx/c2functions/builder.go
+++ b/C2_Profiles/httpx/httpx/c2functions/builder.go
@@ -596,7 +596,7 @@ var httpxc2parameters = []c2structs.C2Parameter{
 	},
 	{
 		Name:          "callback_domains",
-		Description:   "Array of callback domains to communicate with",
+		Description:   "Array of callback domains as http(s)://host:port (e.g. https://example.com:443)",
 		DefaultValue:  []string{"https://example.com:443"},
 		ParameterType: c2structs.C2_PARAMETER_TYPE_ARRAY,
 		Required:      true,


### PR DESCRIPTION
C2_Profiles/httpx/httpx/c2functions/builder.go

  - Added UiPosition field (1-12) to all parameters for UI display ordering
  - Added 3 proxy parameters: proxy_host (host:port), proxy_user, proxy_pass
  - Removed proxy_port (as is specified in http c2 profile) (redundant — port embedded in proxy_host)
  - Updated callback_domains description to "Array of callback domains as http(s)://host:port (e.g. https://example.com:443)"
 
  C2_Profiles/httpx/go.mod

  - Bumped MythicContainer from v1.4.19 to v1.6.4 (required for UiPosition support)
  - Bumped Go version from 1.23.0 to 1.25.1 (required by MythicContainer v1.6.4)
  - Removed toolchain go1.23.3 directive

  C2_Profiles/httpx/Dockerfile

  - Bumped base image from golang:1.23 to golang:1.25
  - Added go mod tidy step before make build to regenerate go.sum for the updated dependency