### PR TITLE
Base64url decoding support nopadding

### DIFF
--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -22,23 +22,21 @@ func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-	if len(prev) > 0 {
-		if prev[len(prev)-1] == '=' {
-			decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-			decoded := make([]byte, decodedLength)
-			actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
-			if err == nil {
-				return decoded[:actualDecoded], nil
-			}
-		} else {
-			decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
-			decoded := make([]byte, decodedLength)
-			actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
-			if err != nil {
-				return nil, err
-			}
-			return decoded[:actualDecoded], nil	
+	if len(prev) > 0 && prev[len(prev)-1] == '=' {
+		decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+		decoded := make([]byte, decodedLength)
+		actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+		if err == nil {
+			return decoded[:actualDecoded], nil
 		}
+	} else {
+		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+		decoded := make([]byte, decodedLength)
+		actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
+		if err != nil {
+			return nil, err
+		}
+		return decoded[:actualDecoded], nil	
 	}
 }
 

--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -33,11 +33,11 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
 		decoded := make([]byte, decodedLength)
 		actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return decoded[:actualDecoded], nil	
 		}
-		return decoded[:actualDecoded], nil	
 	}
+	return nil, err
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -28,18 +28,9 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 	if err == nil {
 		return decoded[:actualDecoded], nil
 	}
-	decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
-	decoded = make([]byte, decodedLength))
+	decodedLength = base64.RawURLEncoding.DecodedLen(len(prev))
+	decoded = make([]byte, decodedLength)
 	actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
-	if err != nil {
-		return nil, err
-	}
-	return decoded[:actualDecoded], nil
-}
-func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-	decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-	decoded := make([]byte, decodedLength)
-	actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
 	if err != nil {
 		return nil, err
 	}

--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -23,6 +23,21 @@ func transformBase64URL(prev []byte, value string) ([]byte, error) {
 }
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 	decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+        decoded := make([]byte, decodedLength)
+	actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+	if err == nil {
+		return decoded[:actualDecoded], nil
+	}
+	decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+	decoded = make([]byte, decodedLength))
+	actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
+	if err != nil {
+		return nil, err
+	}
+	return decoded[:actualDecoded], nil
+}
+func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
+	decodedLength := base64.URLEncoding.DecodedLen(len(prev))
 	decoded := make([]byte, decodedLength)
 	actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
 	if err != nil {

--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -22,19 +22,24 @@ func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-	decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-        decoded := make([]byte, decodedLength)
-	actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
-	if err == nil {
-		return decoded[:actualDecoded], nil
+	if len(prev) > 0 {
+		if prev[len(prev)-1] == '=' {
+			decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+			decoded := make([]byte, decodedLength)
+			actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+			if err == nil {
+				return decoded[:actualDecoded], nil
+			}
+		} else {
+			decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+			decoded := make([]byte, decodedLength)
+			actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
+			if err != nil {
+				return nil, err
+			}
+			return decoded[:actualDecoded], nil	
+		}
 	}
-	decodedLength = base64.RawURLEncoding.DecodedLen(len(prev))
-	decoded = make([]byte, decodedLength)
-	actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
-	if err != nil {
-		return nil, err
-	}
-	return decoded[:actualDecoded], nil
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2_code/webserver/transforms.go
@@ -29,6 +29,7 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		if err == nil {
 			return decoded[:actualDecoded], nil
 		}
+		return nil, err
 	} else {
 		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
 		decoded := make([]byte, decodedLength)
@@ -36,8 +37,8 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		if err == nil {
 			return decoded[:actualDecoded], nil	
 		}
+		return nil, err
 	}
-	return nil, err
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -24,23 +24,21 @@ func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-	if len(prev) > 0 {
-		if prev[len(prev)-1] == '=' {
-			decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-			decoded := make([]byte, decodedLength)
-			actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
-			if err == nil {
-				return decoded[:actualDecoded], nil
-			}
-		} else {
-			decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
-			decoded := make([]byte, decodedLength)
-			actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
-			if err != nil {
-				return nil, err
-			}
-			return decoded[:actualDecoded], nil	
+	if len(prev) > 0 && prev[len(prev)-1] == '=' {
+		decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+		decoded := make([]byte, decodedLength)
+		actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+		if err == nil {
+			return decoded[:actualDecoded], nil
 		}
+	} else {
+		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+		decoded := make([]byte, decodedLength)
+		actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
+		if err != nil {
+			return nil, err
+		}
+		return decoded[:actualDecoded], nil	
 	}
 }
 

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -35,7 +35,7 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		} else {
 			decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
 			decoded := make([]byte, decodedLength)
-			actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
+			actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
 			if err != nil {
 				return nil, err
 			}

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -23,7 +23,6 @@ func transformBase64Reverse(prev []byte, value string) ([]byte, error) {
 func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
-}
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
         decodedLength := base64.URLEncoding.DecodedLen(len(prev))
         decoded := make([]byte, decodedLength)

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -35,11 +35,11 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
 		decoded := make([]byte, decodedLength)
 		actualDecoded, err := base64.RawURLEncoding.Decode(decoded, prev)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			return decoded[:actualDecoded], nil	
 		}
-		return decoded[:actualDecoded], nil	
 	}
+	return nil, err
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -24,19 +24,24 @@ func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-        decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-        decoded := make([]byte, decodedLength)
-        actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
-        if err == nil {
-                return decoded[:actualDecoded], nil
-        }
-        decodedLength = base64.RawURLEncoding.DecodedLen(len(prev))
-        decoded = make([]byte, decodedLength)
-        actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
-        if err != nil {
-                return nil, err
-        }
-        return decoded[:actualDecoded], nil
+	if len(prev) > 0 {
+		if prev[len(prev)-1] == '=' {
+			decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+			decoded := make([]byte, decodedLength)
+			actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+			if err == nil {
+				return decoded[:actualDecoded], nil
+			}
+		} else {
+			decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+			decoded := make([]byte, decodedLength)
+			actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
+			if err != nil {
+				return nil, err
+			}
+			return decoded[:actualDecoded], nil	
+		}
+	}
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -30,7 +30,7 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
         if err == nil {
                 return decoded[:actualDecoded], nil
         }
-        decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+        decodedLength = base64.RawURLEncoding.DecodedLen(len(prev))
         decoded = make([]byte, decodedLength)
         actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
         if err != nil {

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -23,14 +23,21 @@ func transformBase64Reverse(prev []byte, value string) ([]byte, error) {
 func transformBase64URL(prev []byte, value string) ([]byte, error) {
 	return []byte(base64.URLEncoding.EncodeToString(prev)), nil
 }
+}
 func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
-	decodedLength := base64.URLEncoding.DecodedLen(len(prev))
-	decoded := make([]byte, decodedLength)
-	actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
-	if err != nil {
-		return nil, err
-	}
-	return decoded[:actualDecoded], nil
+        decodedLength := base64.URLEncoding.DecodedLen(len(prev))
+        decoded := make([]byte, decodedLength)
+        actualDecoded, err := base64.URLEncoding.Decode(decoded, prev)
+        if err == nil {
+                return decoded[:actualDecoded], nil
+        }
+        decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
+        decoded = make([]byte, decodedLength))
+        actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
+        if err != nil {
+                return nil, err
+        }
+        return decoded[:actualDecoded], nil
 }
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -31,7 +31,7 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
                 return decoded[:actualDecoded], nil
         }
         decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
-        decoded = make([]byte, decodedLength))
+        decoded = make([]byte, decodedLength)
         actualDecoded, err = base64.RawURLEncoding.Decode(decoded, prev)
         if err != nil {
                 return nil, err

--- a/C2_Profiles/httpx/httpx/c2functions/transforms.go
+++ b/C2_Profiles/httpx/httpx/c2functions/transforms.go
@@ -31,6 +31,7 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		if err == nil {
 			return decoded[:actualDecoded], nil
 		}
+		return nil, err
 	} else {
 		decodedLength := base64.RawURLEncoding.DecodedLen(len(prev))
 		decoded := make([]byte, decodedLength)
@@ -38,9 +39,10 @@ func transformBase64URLReverse(prev []byte, value string) ([]byte, error) {
 		if err == nil {
 			return decoded[:actualDecoded], nil	
 		}
+		return nil, err
 	}
-	return nil, err
 }
+
 
 func transformPrepend(prev []byte, value string) ([]byte, error) {
 	return append([]byte(value), prev...), nil


### PR DESCRIPTION
Hi, I'm not sure how to best raise a PR on this repo, sorry if not appropriate.

I've been doing some debugging on an agent using HTTPX, and was a bit confused about the base64 implementation, particularly in GET requests.

Long story short, it appears padding is needed even when base64url encoding and passing as query strings or cookies which is a bit weird and suspicious a behaviour I think. Not sure it qualifies as a bug nor broken but definitely weird. Sending unpadded results in an error.

I've tested this patch that appears to work fine for my use case, where it tries padded and will then try unpadded and fall back to failure after this. Is this a reasonable approach? If so, can it be merged?

Base64 could maybe do with the change too to allow some flexibility in agents, but the behaviour only really bothers me on the URL encoded version so that's all I've touched here.